### PR TITLE
Add MVN_COMMAND arg to Dockerfiles

### DIFF
--- a/docker-files/Dockerfile
+++ b/docker-files/Dockerfile
@@ -16,9 +16,11 @@
 ###############################################################################
 FROM maven:3.3-jdk-8-alpine
 
+ARG MVN_COMMAND="mvn dependency:copy -q"
+
 COPY docker-files/pom.xml .
 
-RUN mvn dependency:copy -q
+RUN $MVN_COMMAND
 
 FROM alpine:3.6
 MAINTAINER Jim White <james_white2@dell.com>

--- a/docker-files/Dockerfile.aarch64
+++ b/docker-files/Dockerfile.aarch64
@@ -17,11 +17,13 @@
 FROM arm64v8/alpine:3.6
 MAINTAINER Federico Claramonte <fede.claramonte@caviumnetworks.com>
 
+ARG MVN_COMMAND="mvn dependency:copy -q"
+
 RUN apk --update add openjdk8-jre maven
 
 COPY docker-files/pom.xml .
 
-RUN mvn dependency:copy -q
+RUN $MVN_COMMAND
 
 FROM arm64v8/alpine:3.6
 

--- a/docker-files/pom.xml
+++ b/docker-files/pom.xml
@@ -11,13 +11,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.edgexfoundry</groupId>
 	<artifactId>device-modbus</artifactId>
-	<version>0.5.0-SNAPSHOT</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<name>device-modbus</name>
 	<description>EdgeX Foundry device-modbus</description>
 
     <properties>
         <nexusproxy>https://nexus.edgexfoundry.org</nexusproxy>
         <repobasepath>content/repositories</repobasepath>
+        <stagingpath>staging</stagingpath>
     </properties>
     
     <build>
@@ -31,7 +32,7 @@
                         <artifactItem>
                             <groupId>org.edgexfoundry</groupId>
                             <artifactId>device-modbus</artifactId>
-                            <version>0.5.0-SNAPSHOT</version>
+                            <version>0.6.0-SNAPSHOT</version>
                             <outputDirectory>.</outputDirectory>
                             <destFileName>device-modbus.jar</destFileName>
                         </artifactItem>
@@ -49,7 +50,7 @@
 		<repository>
                        <id>staging</id>
                        <name>EdgeX Staging Repository</name>
-                       <url>${nexusproxy}/${repobasepath}/staging</url>
+                       <url>${nexusproxy}/${repobasepath}/${stagingpath}</url>
                </repository>
                <repository>
                        <id>snapshots</id>


### PR DESCRIPTION
This will let us override the mvn command to point
at a particular nexus repo.

Signed-off-by: Jeremy Phelps <jphelps@linuxfoundation.org>